### PR TITLE
Fix code scanning alert no. 1: Incorrect suffix check

### DIFF
--- a/packages/formatter-html/src/assets/js/scan/scanner-common.js
+++ b/packages/formatter-html/src/assets/js/scan/scanner-common.js
@@ -212,11 +212,14 @@
     };
 
     var endsWith = function (searchStr, str) {
+        if (typeof str.endsWith === 'function') {
+            return str.endsWith(searchStr);
+        }
         var length = str.length;
         var searchLength = searchStr.length;
         var position = str.indexOf(searchStr);
 
-        return (length - searchLength) === position;
+        return position !== -1 && (length - searchLength) === position;
     };
 
     var onPopState = function () {


### PR DESCRIPTION
Fixes [https://github.com/akaday/hint/security/code-scanning/1](https://github.com/akaday/hint/security/code-scanning/1)

To fix the problem, we need to modify the `endsWith` function to handle the case where `indexOf` returns -1. This can be done by explicitly checking if the returned index is -1 and ensuring the substring length is not greater than the string length. If `String.prototype.endsWith` is available, we should use it for a more straightforward and reliable implementation.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
