### PR TITLE
Refactor yarn.lock

### DIFF
--- a/packages/extension-vscode/src/utils/packages.ts
+++ b/packages/extension-vscode/src/utils/packages.ts
@@ -1,6 +1,6 @@
 import { hasFile } from './fs';
 import { run } from './process';
-import { resolveYarnLockConflicts } from '@hint/utils/dist/src/has-yarnlock';
+import { resolveYarnLockConflicts, hasYarnLock } from '@hint/utils/dist/src/has-yarnlock';
 
 export type LoadOptions = {
     paths?: string[];

--- a/packages/utils/tests/npm.ts
+++ b/packages/utils/tests/npm.ts
@@ -14,6 +14,10 @@ type HasYarnLock = {
     hasYarnLock: () => Promise<boolean>;
 };
 
+type ResolveYarnLockConflicts = {
+    resolveYarnLockConflicts: () => Promise<void>;
+};
+
 type CWD = () => string;
 
 type Logger = {
@@ -39,6 +43,7 @@ type NPMContext = {
     findPackageRootModule: FindPackageRootModule;
     fs: Fs;
     hasYarnLock: HasYarnLock;
+    resolveYarnLockConflicts: ResolveYarnLockConflicts;
     loadJSONFileModule: LoadJSONFileModule;
     logger: Logger;
     npmRegistryFetch: NPMRegistryFetch;
@@ -69,6 +74,11 @@ const initContext = (t: ExecutionContext<NPMContext>) => {
             return Promise.resolve(false);
         }
     };
+    t.context.resolveYarnLockConflicts = {
+        resolveYarnLockConflicts() {
+            return Promise.resolve();
+        }
+    };
     t.context.loadJSONFileModule = (): string => {
         return '';
     };
@@ -94,7 +104,10 @@ const initContext = (t: ExecutionContext<NPMContext>) => {
 
 const loadScript = (context: NPMContext) => {
     return proxyquire('../src/npm', {
-        './has-yarnlock': context.hasYarnLock,
+        './has-yarnlock': {
+            hasYarnLock: context.hasYarnLock.hasYarnLock,
+            resolveYarnLockConflicts: context.resolveYarnLockConflicts.resolveYarnLockConflicts
+        },
         './logging': context.logger,
         './packages': { findPackageRoot: context.findPackageRootModule },
         '@hint/utils-fs': {


### PR DESCRIPTION
Refactor `packages/extension-vscode/src/utils/packages.ts` and `packages/utils/tests/npm.ts` to handle `yarn.lock` conflicts and presence.

* **packages/extension-vscode/src/utils/packages.ts**
  - Import `resolveYarnLockConflicts` and `hasYarnLock` from `@hint/utils/dist/src/has-yarnlock`.

* **packages/utils/tests/npm.ts**
  - Add `resolveYarnLockConflicts` type and function to context.
  - Update `loadScript` to include `resolveYarnLockConflicts` and `hasYarnLock` from `./has-yarnlock`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/akaday/hint/pull/109?shareId=745d647e-789c-4e38-a769-4ea1040e25dc).