### PR TITLE
Fix yarn.lock conflicts

### DIFF
--- a/packages/utils/src/has-yarnlock.ts
+++ b/packages/utils/src/has-yarnlock.ts
@@ -22,7 +22,9 @@ export const resolveYarnLockConflicts = (directory: string): Promise<void> => {
                 return reject(err);
             }
 
-            const resolvedData = data.replace(/<<<<<<< HEAD[\s\S]*?=======([\s\S]*?)>>>>>>> [\s\S]*?\n/g, '$1');
+            const resolvedData = data.replace(/<<<<<<< HEAD[\s\S]*?=======([\s\S]*?)>>>>>>> [\s\S]*?\n/g, '$1')
+                                     .replace(/<<<<<<<[\s\S]*?=======([\s\S]*?)>>>>>>>[\s\S]*?\n/g, '$1')
+                                     .replace(/=======([\s\S]*?)>>>>>>>[\s\S]*?\n/g, '$1');
 
             writeFile(yarnLockPath, resolvedData, 'utf8', (err) => {
                 if (err) {

--- a/packages/utils/tests/has-yarnlock.ts
+++ b/packages/utils/tests/has-yarnlock.ts
@@ -25,3 +25,21 @@ test(`resolves conflicts in yarn.lock file`, async (t) => {
 
     t.is(hasLockFile, true);
 });
+
+test(`resolves conflicts with multiple conflict markers in yarn.lock file`, async (t) => {
+    const dirWithYarnLock = path.join(__dirname, 'fixtures', 'dirWithMultipleConflicts');
+    await resolveYarnLockConflicts(dirWithYarnLock);
+
+    const hasLockFile = await hasYarnLock(dirWithYarnLock);
+
+    t.is(hasLockFile, true);
+});
+
+test(`resolves conflicts with nested conflict markers in yarn.lock file`, async (t) => {
+    const dirWithYarnLock = path.join(__dirname, 'fixtures', 'dirWithNestedConflicts');
+    await resolveYarnLockConflicts(dirWithYarnLock);
+
+    const hasLockFile = await hasYarnLock(dirWithYarnLock);
+
+    t.is(hasLockFile, true);
+});


### PR DESCRIPTION
Update `resolveYarnLockConflicts` function to handle additional conflict scenarios in `yarn.lock` file.

* **packages/utils/src/has-yarnlock.ts**
  - Modify `resolveYarnLockConflicts` to handle multiple conflict markers and nested conflict markers in `yarn.lock` file.

* **packages/utils/tests/has-yarnlock.ts**
  - Add tests for resolving conflicts with multiple conflict markers in `yarn.lock` file.
  - Add tests for resolving conflicts with nested conflict markers in `yarn.lock` file.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/akaday/hint/pull/110?shareId=6345b2f3-2c39-4751-9722-5ebd8b601197).